### PR TITLE
Change ShouldNotUpdate to Higher Order Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,51 @@
 # ShouldNotUpdate
 [![npm version](https://badge.fury.io/js/should-not-update.svg)](https://badge.fury.io/js/should-not-update) [![Build Status](https://travis-ci.org/codepunkt/should-not-update.svg?branch=master)](https://travis-ci.org/codepunkt/should-not-update) [![Coverage Status](https://coveralls.io/repos/github/codepunkt/should-not-update/badge.svg?branch=master)](https://coveralls.io/github/codepunkt/should-not-update?branch=master)
 
-Simple component utilizing the `shouldComponentUpdate` lifecycle hook. Wrap it around child components that you don't want to rerender on property changes.
+Simple higher order component utilizing the `shouldComponentUpdate` lifecycle hook.
 ```javascript
 import ShouldNotUpdate from 'should-not-update'
 
-const MyComponent = ({ someProp }) => (
-  <ShouldNotUpdate>
-    <InnerComponent someProp={someProp}>
-      This is not updating on property change
-    </InnerComponent>
-  </ShouldNotUpdate>
-)
-```
-### Rendered component
-By default, `ShouldNotUpdate` will render as a `div` element, but that can be changed by setting the `component` prop, which accepts either a tag name string (such as 'div' or 'span')
-```javascript
-<ShouldNotUpdate component="ul">
-```
-or a React component type (a class or a function), which should render their children to be useful.
-```javascript
-const MyComponent = ({ children }) => (
-  <div>
-    {children}
-  </div>
-)
+const ShouldNotUpdateComponent = ShouldNotUpdate(InnerComponent)
 
-<ShouldNotUpdate component={MyComponent}>
+const MyComponent = ({ someProp }) => (
+  <ShouldNotUpdateComponent someProp={someProp}>
+    This is not updating on property change
+  </ShouldNotUpdateComponent>
+)
 ```
+
 ### Exceptions to the rule
-Sometimes you want child components to re-render under certain conditions. You can add these conditions by setting the `exceptWhen` prop.
+Sometimes you want components to re-render under certain conditions. You can add these conditions by setting the `exceptWhen` parameter.
 ```javascript
+const ShouldNotUpdateComponent = ShouldNotUpdate(InnerComponent,
+  (nextProps) => nextProps.someProp === 42)
+
 const MyComponent = ({ someProp }) => (
-  <ShouldNotUpdate exceptWhen={someProp === 42}>
-    <InnerComponent someProp={someProp}>
-      This only updates on property change when someProp is 42
-    </InnerComponent>
-  </ShouldNotUpdate>
+  <ShouldNotUpdateComponent someProp={someProp}>
+    This only updates on property change when someProp is 42
+  </ShouldNotUpdateComponent>
 )
 ```
 
-### Other properties
-All properties besides `children`, `component` and `exceptWhen` are directly passed to the rendered component.
-```javascript
-const MyComponent = ({ someProp }) => (
-  <ShouldNotUpdate component="nav" role="navigation">
-    <InnerComponent someProp={someProp}>
-      This is not updating on property change
-    </InnerComponent>
-  </ShouldNotUpdate>
-)
-```
 ### Use cases
 Amongst others, one possible use case is not re-rendering static children of a [react-motion](https://github.com/chenglou/react-motion) spring animation on every animation frame.
 ```javascript
 import { Link } from 'react-router'
 import { Motion, spring } from 'react-motion'
 
+const ShouldNotUpdateComponent = ShouldNotUpdate(() => (
+  <ul>
+    <li><Link to="/">Home</Link></li>
+  </ul>
+)))
+
 const OffCanvas = ({ isVisible }) => (
   <Motion style={{ left: spring(isVisible ? 0 : -250) }}>
-    {style => <nav role="navigation" style={style}>
-      <ShouldNotUpdate component="ul">
-        <li><Link to="/">Home</Link></li>
-      </ShouldNotUpdate>
-    </nav>}
+    {style => (
+      <nav role="navigation" style={style}>
+        <ShouldNotUpdateComponent />
+      </nav>
+    )}
   </Motion>
 );
 ```

--- a/index.js
+++ b/index.js
@@ -1,28 +1,13 @@
 import React from 'react'
 
-class ShouldNotUpdate extends React.Component {
-  shouldComponentUpdate() {
-    return this.props.exceptWhen
+const ShouldNotUpdate = (Component, exceptWhen = () => false) => class extends React.PureComponent {
+  shouldComponentUpdate(nextProps) {
+    return exceptWhen(nextProps)
   }
+
   render() {
-    const { children, component, ...rest } = this.props
-    delete rest.exceptWhen
-    return React.createElement(component, rest, children)
+    return <Component {...this.props} />
   }
-}
-
-ShouldNotUpdate.propTypes = {
-  component: React.PropTypes.oneOfType([
-    React.PropTypes.func,
-    React.PropTypes.node,
-  ]),
-  children: React.PropTypes.node.isRequired,
-  exceptWhen: React.PropTypes.bool,
-}
-
-ShouldNotUpdate.defaultProps = {
-  component: 'div',
-  exceptWhen: false,
 }
 
 export default ShouldNotUpdate

--- a/index.test.js
+++ b/index.test.js
@@ -2,74 +2,42 @@ import React from 'react'
 import { mount, shallow } from 'enzyme'
 import ShouldNotUpdate from './index'
 
-describe('<ShouldNotUpdate />', () => {
-  test('warns when rendered without children', () => {
-    console.error = jest.fn()
-    const rendered = shallow(<ShouldNotUpdate />)
-    expect(console.error.mock.calls.length).toEqual(1)
-    const regexp = /prop `children` is marked as required/
-    expect(console.error.mock.calls[0][0]).toMatch(regexp)
-  })
+describe('ShouldNotUpdate HOC', () => {
+  let InnerComponent
+  let fn
 
-  test('renders as div element by default', () => {
-    const rendered = shallow(<ShouldNotUpdate>wat</ShouldNotUpdate>)
-    expect(rendered.find('div').length).toEqual(1)
-  })
+  beforeEach(() => {
+    fn = jest.fn()
 
-  test('renders as given tag name string', () => {
-    const rendered = shallow(<ShouldNotUpdate component="footer">wat</ShouldNotUpdate>)
-    expect(rendered.find('footer').length).toEqual(1)
-  })
-
-  test('renders as given react component types', () => {
-    const Headline = ({ children }) => <h1>{children}</h1>
-    const rendered = mount(<ShouldNotUpdate component={Headline}>wat</ShouldNotUpdate>)
-    expect(rendered.find('h1').length).toEqual(1)
-  })
-
-  test('doesnt update child components on property change', () => {
-    const fn = jest.fn()
-
-    const InnerComponent = ({ name }) => {
+    InnerComponent = ({ name }) => {
       fn()
       return <div className={name} />
     }
-
-    const UpdateChildren = ({ name }) => (
-      <InnerComponent name={name} />
-    )
-    const DontUpdateChildren = ({ name }) => (
-      <ShouldNotUpdate>
-        <InnerComponent name={name} />
-      </ShouldNotUpdate>
-    )
-
-    const rendered1 = mount(<DontUpdateChildren name="foo" />)
-    const rendered2 = mount(<UpdateChildren name="foo" />)
-    rendered1.setProps({ name: 'bar' })
-    rendered2.setProps({ name: 'bar' })
-
-    expect(fn.mock.calls.length).toEqual(3)
   })
 
-  test('updates child components when given criteria matches', () => {
-    const fn = jest.fn()
+  test('not enhanced component should update on prop change', () => {
+    const rendered = mount(<InnerComponent name="foo" />)
+    expect(fn.mock.calls.length).toEqual(1)
 
-    const InnerComponent = ({ callback, name }) => {
-      callback()
-      return <div className={name} />
-    }
-
-    const SomeTimesUpdateChildren = ({ name }) => (
-      <ShouldNotUpdate exceptWhen={name === 'bar'}>
-        <InnerComponent name={name} callback={fn}/>
-      </ShouldNotUpdate>
-    )
-
-    const rendered = mount(<SomeTimesUpdateChildren name="foo" />)
     rendered.setProps({ name: 'bar' })
-    rendered.setProps({ name: 'baz' })
+    expect(fn.mock.calls.length).toEqual(2)
+  })
 
+  test('enhanced component should not update on prop change', () => {
+    const ShouldNotUpdateInnerComponent = ShouldNotUpdate(InnerComponent)
+    const rendered = mount(<ShouldNotUpdateInnerComponent name="foo" />)
+    expect(fn.mock.calls.length).toEqual(1)
+
+    rendered.setProps({ name: 'bar' })
+    expect(fn.mock.calls.length).toEqual(1)
+  })
+
+  test('enhanced component should update when `exceptWhen` returns true', () => {
+    const ShouldNotUpdateInnerComponent = ShouldNotUpdate(InnerComponent, (nextProps) => nextProps.name === 'bar')
+    const rendered = mount(<ShouldNotUpdateInnerComponent name="foo" />)
+    expect(fn.mock.calls.length).toEqual(1)
+
+    rendered.setProps({ name: 'bar' })
     expect(fn.mock.calls.length).toEqual(2)
   })
 })


### PR DESCRIPTION
Changes `ShouldNotUpdate` from a wrapping Component to a Higher Order
Component. Removes the need for `component` prop.